### PR TITLE
Fix eval-within-parens.

### DIFF
--- a/funcs.el
+++ b/funcs.el
@@ -51,5 +51,5 @@
 (defun sclang-evaluate-within-parens ()
   "Evaluate code within outermost parentheses (assumes active evil mode)"
   (interactive)
-  (setq unread-command-events (listify-key-sequence "vi(,,fd")))
+  (setq unread-command-events (listify-key-sequence "mz(v),,v`z")))
 

--- a/funcs.el
+++ b/funcs.el
@@ -51,5 +51,4 @@
 (defun sclang-evaluate-within-parens ()
   "Evaluate code within outermost parentheses (assumes active evil mode)"
   (interactive)
-  (setq unread-command-events (listify-key-sequence "mz(v),,v`z")))
-
+  (setq unread-command-events (listify-key-sequence "mz(vi),,v`z")))


### PR DESCRIPTION
Change the VIM command to:
1. Mark current position and  map it  to ‘z’.
2. Find the enclosing parenthesis.  In original version  this was done after entering visual-mode.
3. Enter visual-mode.
4. Select code block.
5. Evaluate code.
6. Enter normal-mode.
7. Go back to marked position.